### PR TITLE
source & target = 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,8 @@
 	<packaging>pom</packaging>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.5</maven.compiler.source>
+		<maven.compiler.target>1.5</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Set maven.compiler.source and target to 1.5.
Fixes compilation errors with default maven configuration:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project xtend-annotations: Compilation failure: Compilation failure:
[ERROR] ...../xtend-annotations/xtend-annotations/src/main/xtend-gen/de/oehme/xtend/annotation/data/ImmutableProcessor.java:[24,1] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable annotations)
[ERROR] ...../xtend-annotations/xtend-annotations/src/main/xtend-gen/de/oehme/xtend/annotation/data/ImmutableProcessor.java:[40,20] error: generics are not supported in -source 1.3
```
