### PR TITLE
Use type literals in template

### DIFF
--- a/src/main/java/de/oehme/xtend/contrib/Messages.xtend
+++ b/src/main/java/de/oehme/xtend/contrib/Messages.xtend
@@ -63,8 +63,8 @@ class MessagesProcessor extends AbstractClassProcessor {
 					returnType = string
 					body = '''
 						String pattern = bundle.getString("«key»");
-						«MessageFormat» format = new MessageFormat(pattern);
-						return format.format(new Object[]{«parameters.join(", ")[simpleName]»});
+						«MessageFormat» format = new «MessageFormat»(pattern);
+						return format.format(new «Object»[]{«parameters.join(", ")[simpleName]»});
 					'''
 					docComment = pattern
 					primarySourceElement = cls


### PR DESCRIPTION
Hard coded type names may lead to problem in rare situations, e.g. the messages annotation should not break for types like 
class X<MessageFormat> {}
